### PR TITLE
ci(gemfile): add linux platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       activesupport (>= 6.1.0)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -100,6 +101,8 @@ GEM
     method_source (1.1.0)
     minitest (5.26.1)
     nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -216,6 +219,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   dotenv-rails


### PR DESCRIPTION
To fix CI pipeline error in "Setup Ruby" stage

**Changes**: 
* Add x86_64-linux platform to Gemfile.lock