### PR TITLE
fix: bump initial commit  

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       activesupport (>= 6.1.0)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -100,6 +101,8 @@ GEM
     method_source (1.1.0)
     minitest (5.26.1)
     nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -216,6 +219,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   dotenv-rails

--- a/lib/chatkit/conversation/response/thread/item.rb
+++ b/lib/chatkit/conversation/response/thread/item.rb
@@ -6,6 +6,8 @@ module ChatKit
       class Thread
         # Represents an item in a thread.
         class Item
+          REQUIRED_ATTRIBUTES = %w[id thread_id created_at].freeze
+
           # @!attribute [rw] id
           #  @return [String]
           attr_accessor :id
@@ -76,6 +78,10 @@ module ChatKit
             # @param data [Hash] The item data from the event
             # @return [Item]
             def from_event(data)
+              missing_attrs = REQUIRED_ATTRIBUTES.reject { |attr| data.key?(attr) }
+              raise ArgumentError, "Missing required attributes: #{missing_attrs.join(', ')}" unless missing_attrs.empty?
+
+
               new(
                 id: data["id"],
                 thread_id: data["thread_id"],
@@ -118,7 +124,7 @@ module ChatKit
             if @workflow
               @workflow.update!(data["workflow"])
             else
-              @workflow = parse_workflow_data(data)
+              @workflow = self.class.parse_workflow_data(data)
             end
           end
 
@@ -143,7 +149,7 @@ module ChatKit
           # Parse workflow data from event
           # @param data [Hash] The event data
           # @return [Workflow, nil]
-          def parse_workflow_data(data)
+          def self.parse_workflow_data(data)
             return nil unless data["workflow"]
 
             Workflow.from_event(data["workflow"])

--- a/lib/chatkit/files/response.rb
+++ b/lib/chatkit/files/response.rb
@@ -29,14 +29,14 @@ module ChatKit
       attr_accessor :upload_url
 
       # @param id [String] - The file ID.
-      # @param mime_typee [String] - The MIME type of the file.
+      # @param mime_type [String] - The MIME type of the file.
       # @param name [String] - The name of the file.
       # @param preview_url [String] - The preview URL of the file.
       # @param type [String] - The type of the file.
       # @param upload_url [String] - The upload URL of the file.
-      def initialize(id:, mime_typee:, name:, preview_url:, type:, upload_url:)
+      def initialize(id:, mime_type:, name:, preview_url:, type:, upload_url:)
         @id = id
-        @mime_type = mime_typee
+        @mime_type = mime_type
         @name = name
         @preview_url = preview_url
         @type = type
@@ -47,7 +47,7 @@ module ChatKit
         def deserialize(data)
           new(
             id: data["id"],
-            mime_typee: data["mime_type"],
+            mime_type: data["mime_type"],
             name: data["name"],
             preview_url: data["preview_url"],
             type: data["type"],

--- a/lib/chatkit/session.rb
+++ b/lib/chatkit/session.rb
@@ -21,6 +21,10 @@ module ChatKit
       ENABLED = true
     end
 
+    # @!attribute [r] client
+    #  @return [Ruby::ChatKit::Client] The ChatKit client instance.
+    attr_reader :client
+
     # @!attribute [rw] user_id
     #  @return [String] The ID of the user.
     attr_accessor :user_id

--- a/spec/chatkit/files/response_spec.rb
+++ b/spec/chatkit/files/response_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ChatKit::Files::Response do
       it "initializes with all provided values" do
         response = described_class.new(
           id: "file_test123",
-          mime_typee: "application/pdf",
+          mime_type: "application/pdf",
           name: "document.pdf",
           preview_url: "https://example.com/preview/file_test123",
           type: "document",
@@ -40,7 +40,7 @@ RSpec.describe ChatKit::Files::Response do
       it "raises an ArgumentError when id is missing" do
         expect do
           described_class.new(
-            mime_typee: "application/pdf",
+            mime_type: "application/pdf",
             name: "document.pdf",
             preview_url: "https://example.com/preview",
             type: "document",
@@ -49,7 +49,7 @@ RSpec.describe ChatKit::Files::Response do
         end.to raise_error(ArgumentError, /missing keyword.*id/)
       end
 
-      it "raises an ArgumentError when mime_typee is missing" do
+      it "raises an ArgumentError when mime_type is missing" do
         expect do
           described_class.new(
             id: "file_test123",
@@ -58,14 +58,14 @@ RSpec.describe ChatKit::Files::Response do
             type: "document",
             upload_url: "https://example.com/upload"
           )
-        end.to raise_error(ArgumentError, /missing keyword.*mime_typee/)
+        end.to raise_error(ArgumentError, /missing keyword.*mime_type/)
       end
 
       it "raises an ArgumentError when name is missing" do
         expect do
           described_class.new(
             id: "file_test123",
-            mime_typee: "application/pdf",
+            mime_type: "application/pdf",
             preview_url: "https://example.com/preview",
             type: "document",
             upload_url: "https://example.com/upload"
@@ -77,7 +77,7 @@ RSpec.describe ChatKit::Files::Response do
         expect do
           described_class.new(
             id: "file_test123",
-            mime_typee: "application/pdf",
+            mime_type: "application/pdf",
             name: "document.pdf",
             type: "document",
             upload_url: "https://example.com/upload"
@@ -89,7 +89,7 @@ RSpec.describe ChatKit::Files::Response do
         expect do
           described_class.new(
             id: "file_test123",
-            mime_typee: "application/pdf",
+            mime_type: "application/pdf",
             name: "document.pdf",
             preview_url: "https://example.com/preview",
             upload_url: "https://example.com/upload"
@@ -101,7 +101,7 @@ RSpec.describe ChatKit::Files::Response do
         expect do
           described_class.new(
             id: "file_test123",
-            mime_typee: "application/pdf",
+            mime_type: "application/pdf",
             name: "document.pdf",
             preview_url: "https://example.com/preview",
             type: "document"
@@ -216,7 +216,7 @@ RSpec.describe ChatKit::Files::Response do
     let(:response) do
       described_class.new(
         id: "file_test123",
-        mime_typee: "image/jpeg",
+        mime_type: "image/jpeg",
         name: "photo.jpg",
         preview_url: "https://example.com/preview/file_test123",
         type: "image",


### PR DESCRIPTION
This PR focuses on fixes `ChatKit` codebase. The most significant updates include enforcing required attributes for thread items, fixing a typo in the `mime_type` parameter.

Changes:
* Fix CI "setup ruby" stage
* Fix a typo
* Fix some method access